### PR TITLE
Switch to tile layout and remove Namava

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # iTV
 
-iTV is a tvOS application that aggregates several Iranian video on demand platforms. The project currently displays a simple list of supported platforms and uses localized Persian strings. Each provider is implemented as a separate module and references a logo asset. Binary image files are omitted from the repository, so the app falls back to system symbols as placeholders.
+iTV is a tvOS application that aggregates several Iranian video on demand platforms. The project currently displays the supported platforms and uses localized Persian strings. Each provider is implemented as a separate module and now includes a vector logo asset.
 
 ## Platforms
 
 - Filimo
-- Namava
 - Film Net
 - Star Net
 

--- a/iTv/ContentView.swift
+++ b/iTv/ContentView.swift
@@ -3,22 +3,32 @@ import SwiftUI
 struct ContentView: View {
     private let modules: [any PlatformModule] = [
         Filimo(),
-        Namava(),
         FilmNet(),
         StarNet()
     ]
 
+    private let columns = [GridItem(.adaptive(minimum: 180))]
+
     var body: some View {
         NavigationStack {
-            List(modules, id: \.id) { module in
-                HStack(spacing: 16) {
-                    Image(systemName: module.logoSystemName)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 64, height: 64)
-                    Text(LocalizedStringKey(module.nameKey))
-                        .font(.title3)
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 20) {
+                    ForEach(modules, id: \.id) { module in
+                        VStack(spacing: 8) {
+                            Image(module.logoAssetName)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(height: 80)
+                            Text(LocalizedStringKey(module.nameKey))
+                                .font(.title3)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.gray.opacity(0.2))
+                        .cornerRadius(12)
+                    }
                 }
+                .padding()
             }
             .navigationTitle(Text("platforms.title"))
         }

--- a/iTv/Localizable.strings
+++ b/iTv/Localizable.strings
@@ -1,5 +1,4 @@
 "filimo.name" = "فیلیمو";
-"namava.name" = "نماوا";
 "filmnet.name" = "فیلم‌نت";
 "starnet.name" = "استارنت";
 "platforms.title" = "پلتفرم‌ها";

--- a/iTv/Platforms/Filimo.swift
+++ b/iTv/Platforms/Filimo.swift
@@ -3,5 +3,5 @@ import SwiftUI
 struct Filimo: PlatformModule {
     let id = UUID()
     let nameKey = "filimo.name"
-    let logoSystemName = "film"
+    let logoAssetName = "Filimo"
 }

--- a/iTv/Platforms/FilmNet.swift
+++ b/iTv/Platforms/FilmNet.swift
@@ -3,5 +3,5 @@ import SwiftUI
 struct FilmNet: PlatformModule {
     let id = UUID()
     let nameKey = "filmnet.name"
-    let logoSystemName = "tv"
+    let logoAssetName = "Filmnet"
 }

--- a/iTv/Platforms/Namava.swift
+++ b/iTv/Platforms/Namava.swift
@@ -1,7 +1,0 @@
-import SwiftUI
-
-struct Namava: PlatformModule {
-    let id = UUID()
-    let nameKey = "namava.name"
-    let logoSystemName = "play.rectangle"
-}

--- a/iTv/Platforms/PlatformModule.swift
+++ b/iTv/Platforms/PlatformModule.swift
@@ -3,12 +3,12 @@ import SwiftUI
 protocol PlatformModule: Identifiable where ID == UUID {
     var id: UUID { get }
     var nameKey: String { get }
-    /// Name of the SF Symbol used as a placeholder logo.
-    var logoSystemName: String { get }
+    /// Name of the logo image stored in the asset catalog.
+    var logoAssetName: String { get }
 }
 
 struct AnyPlatformModule: PlatformModule {
     let id = UUID()
     let nameKey: String
-    let logoSystemName: String
+    let logoAssetName: String
 }

--- a/iTv/Platforms/StarNet.swift
+++ b/iTv/Platforms/StarNet.swift
@@ -3,5 +3,5 @@ import SwiftUI
 struct StarNet: PlatformModule {
     let id = UUID()
     let nameKey = "starnet.name"
-    let logoSystemName = "star"
+    let logoAssetName = "StarNet"
 }


### PR DESCRIPTION
## Summary
- remove Namava module
- use asset-based logos for each remaining provider
- display providers in a tiled grid
- update localization and documentation

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847dc4378fc83309a01c74f2bf6ea04