### PR TITLE
Handle FilmNet home page without wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ iTV is a tvOS application that aggregates several Iranian video on demand platfo
 - Film Net
 - Star Net
 
+## Notes
+
+The FilmNet API responses sometimes omit the `data` container. The home page
+loader now falls back to decoding an array when the `data` field is missing.
+
 ## License
 
 This project is released under the terms of the Business Source License 1.1. See `LICENSE.md` for details.

--- a/iTv/FilmNet/FilmNetService.swift
+++ b/iTv/FilmNet/FilmNetService.swift
@@ -32,7 +32,13 @@ struct FilmNetService {
     func fetchHomePage() async throws -> [Widget] {
         let url = URL(string: "https://api-v2.filmnet.ir/widgets/personal-home-page")!
         let (data, _) = try await URLSession.shared.data(from: url)
-        let decoded = try JSONDecoder().decode(Response.self, from: data)
-        return decoded.data
+        let decoder = JSONDecoder()
+        if let response = try? decoder.decode(Response.self, from: data) {
+            return response.data
+        } else {
+            // Some FilmNet endpoints return an array at the top level instead of
+            // wrapping the widgets in a `data` container.
+            return try decoder.decode([Widget].self, from: data)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- handle FilmNet responses that omit the `data` container
- document the fallback behaviour in the README

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684deef533348330af7e5c380b19269b