### PR TITLE
Handle more FilmNet response shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ iTV is a tvOS application that aggregates several Iranian video on demand platfo
 - Film Net
 - Star Net
 
+## Notes
+
+The FilmNet API is inconsistent about how widgets are returned. Sometimes
+they appear under a `data` field, other times under `data.widgets` or even a
+top-level `widgets` key. When no container is present the API returns the
+array directly. The `FilmNetService` now tries each format in turn so the
+home screen loads regardless of which wrapper is used.
+
 ## License
 
 This project is released under the terms of the Business Source License 1.1. See `LICENSE.md` for details.

--- a/iTv/FilmNet/FilmNetService.swift
+++ b/iTv/FilmNet/FilmNetService.swift
@@ -5,6 +5,20 @@ struct FilmNetService {
         let data: [Widget]
     }
 
+    /// Some responses wrap the widgets under `data.widgets`.
+    struct NestedResponse: Decodable {
+        let data: DataContainer
+
+        struct DataContainer: Decodable {
+            let widgets: [Widget]
+        }
+    }
+
+    /// And others use a `widgets` key directly at the top level.
+    struct WidgetsResponse: Decodable {
+        let widgets: [Widget]
+    }
+
     struct Widget: Decodable, Identifiable {
         let id = UUID()
         let configuration: Configuration
@@ -32,7 +46,24 @@ struct FilmNetService {
     func fetchHomePage() async throws -> [Widget] {
         let url = URL(string: "https://api-v2.filmnet.ir/widgets/personal-home-page")!
         let (data, _) = try await URLSession.shared.data(from: url)
-        let decoded = try JSONDecoder().decode(Response.self, from: data)
-        return decoded.data
+        let decoder = JSONDecoder()
+
+        // 1. Standard `{ "data": [ ... ] }` format.
+        if let response = try? decoder.decode(Response.self, from: data) {
+            return response.data
+        }
+
+        // 2. Nested `{ "data": { "widgets": [ ... ] } }` variant.
+        if let nested = try? decoder.decode(NestedResponse.self, from: data) {
+            return nested.data.widgets
+        }
+
+        // 3. Direct `{ "widgets": [ ... ] }` container.
+        if let container = try? decoder.decode(WidgetsResponse.self, from: data) {
+            return container.widgets
+        }
+
+        // 4. Raw array at the top level.
+        return try decoder.decode([Widget].self, from: data)
     }
 }


### PR DESCRIPTION
## Summary
- handle nested `data.widgets` and top-level `widgets` containers
- document the possible response formats in the README

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684deef533348330af7e5c380b19269b